### PR TITLE
order captures first

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,8 @@ set(STORMPHRAX_COMMON_SRC src/types.h src/main.cpp src/uci.h src/uci.cpp src/cor
 	src/cuckoo.h src/cuckoo.cpp src/eval/nnue/network.h src/eval/nnue/layers.h src/eval/nnue/activation.h
 	src/eval/nnue/output.h src/eval/nnue/input.h src/util/memstream.h src/util/aligned_array.h src/eval/nnue/io.h
 	src/eval/nnue/features.h src/datagen/format.h src/datagen/common.h src/datagen/marlinformat.h
-	src/datagen/marlinformat.cpp src/datagen/viri_binpack.h src/datagen/viri_binpack.cpp src/tb.h src/tb.cpp)
+	src/datagen/marlinformat.cpp src/datagen/viri_binpack.h src/datagen/viri_binpack.cpp src/tb.h src/tb.cpp
+	src/movepick.h)
 
 set(STORMPHRAX_BMI2_SRC src/attacks/bmi2/data.h src/attacks/bmi2/attacks.h src/attacks/bmi2/attacks.cpp)
 set(STORMPHRAX_NON_BMI2_SRC src/attacks/black_magic/data.h src/attacks/black_magic/attacks.h

--- a/src/bench.h
+++ b/src/bench.h
@@ -27,7 +27,7 @@ namespace stormphrax::bench
 #ifdef SP_PGO_PROFILE
 	constexpr i32 DefaultBenchDepth = 3;
 #else
-	constexpr i32 DefaultBenchDepth = 4;
+	constexpr i32 DefaultBenchDepth = 5;
 #endif
 
 	auto run(search::Searcher &searcher, i32 depth = DefaultBenchDepth) -> void;

--- a/src/movegen.h
+++ b/src/movegen.h
@@ -22,7 +22,6 @@
 
 #include "move.h"
 #include "position/position.h"
-#include "see.h"
 
 namespace stormphrax
 {
@@ -34,102 +33,8 @@ namespace stormphrax
 
 	using ScoredMoveList = StaticVector<ScoredMove, DefaultMoveListCapacity>;
 
-	struct MovegenData
-	{
-		ScoredMoveList moves;
-	};
-
 	auto generateNoisy(ScoredMoveList &noisy, const Position &pos) -> void;
 	auto generateQuiet(ScoredMoveList &quiet, const Position &pos) -> void;
 
 	auto generateAll(ScoredMoveList &dst, const Position &pos) -> void;
-
-	struct MovegenStage
-	{
-		static constexpr i32 Start = 0;
-		static constexpr i32 All = Start + 1;
-		static constexpr i32 End = All + 1;
-	};
-
-	template <bool Root, bool GoodNoisiesOnly = false>
-	class MoveGenerator
-	{
-	public:
-		MoveGenerator(const Position &pos, MovegenData &data)
-			: m_pos{pos},
-			  m_data{data}
-		{
-			if constexpr (!Root)
-				m_data.moves.clear();
-		}
-
-		~MoveGenerator() = default;
-
-		[[nodiscard]] inline auto next()
-		{
-			if constexpr (Root)
-			{
-				const auto idx = findNext();
-				return idx == m_data.moves.size() ? NullMove : m_data.moves[idx].move;
-			}
-
-			while (true)
-			{
-				while (m_idx == m_data.moves.size())
-				{
-					++m_stage;
-
-					switch (m_stage)
-					{
-					case MovegenStage::All:
-						generateAll(m_data.moves, m_pos);
-						break;
-
-					default:
-						return NullMove;
-					}
-				}
-
-				if (m_idx == m_data.moves.size())
-					return NullMove;
-
-				const auto idx = findNext();
-				return m_data.moves[idx].move;
-			}
-		}
-
-		[[nodiscard]] inline auto stage() const { return m_stage; }
-
-	private:
-		inline auto findNext()
-		{
-			/*
-			auto best = m_idx;
-			auto bestScore = m_data.moves[m_idx].score;
-
-			for (auto i = m_idx + 1; i < m_data.moves.size(); ++i)
-			{
-				if (m_data.moves[i].score > bestScore)
-				{
-					best = i;
-					bestScore = m_data.moves[i].score;
-				}
-			}
-
-			if (best != m_idx)
-				std::swap(m_data.moves[m_idx], m_data.moves[best]);
-			 */
-
-			return m_idx++;
-		}
-
-		const Position &m_pos;
-
-		i32 m_stage{MovegenStage::Start};
-
-		MovegenData &m_data;
-		u32 m_idx{};
-	};
-
-	using QMoveGenerator = MoveGenerator<false, true>;
 }

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -1,0 +1,142 @@
+/*
+ * Stormphrax, a UCI chess engine
+ * Copyright (C) 2024 Ciekce
+ *
+ * Stormphrax is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Stormphrax is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Stormphrax. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "types.h"
+
+#include "movegen.h"
+
+namespace stormphrax
+{
+	struct MovegenData
+	{
+		ScoredMoveList moves;
+	};
+
+	struct MovegenStage
+	{
+		static constexpr i32 Start = 0;
+		static constexpr i32 GenNoisy = Start + 1;
+		static constexpr i32 Noisy = GenNoisy + 1;
+		static constexpr i32 GenQuiet = Noisy + 1;
+		static constexpr i32 Quiet = GenQuiet + 1;
+		static constexpr i32 End = Quiet + 1;
+	};
+
+	template <bool Root, bool NoisiesOnly = false>
+	class MoveGenerator
+	{
+	public:
+		MoveGenerator(const Position &pos, MovegenData &data)
+			: m_pos{pos},
+			m_data{data}
+		{
+			if constexpr (!Root)
+				m_data.moves.clear();
+		}
+
+		~MoveGenerator() = default;
+
+		[[nodiscard]] inline auto next()
+		{
+			if constexpr (Root)
+			{
+				const auto idx = findNext();
+				return idx == m_data.moves.size() ? NullMove : m_data.moves[idx].move;
+			}
+
+			while (true)
+			{
+				while (m_idx == m_data.moves.size())
+				{
+					++m_stage;
+
+					switch (m_stage)
+					{
+						case MovegenStage::GenNoisy:
+							generateNoisy(m_data.moves, m_pos);
+							[[fallthrough]];
+
+						case MovegenStage::Noisy:
+							break;
+
+						case MovegenStage::GenQuiet:
+							generateQuiet(m_data.moves, m_pos);
+							[[fallthrough]];
+
+						case MovegenStage::Quiet:
+							break;
+
+						default:
+							return NullMove;
+					}
+				}
+
+				if (m_idx == m_data.moves.size())
+					return NullMove;
+
+				const auto idx = findNext();
+				return m_data.moves[idx].move;
+			}
+		}
+
+		[[nodiscard]] inline auto stage() const { return m_stage; }
+
+	private:
+		inline auto findNext()
+		{
+			/*
+			auto best = m_idx;
+			auto bestScore = m_data.moves[m_idx].score;
+
+			for (auto i = m_idx + 1; i < m_data.moves.size(); ++i)
+			{
+				if (m_data.moves[i].score > bestScore)
+				{
+					best = i;
+					bestScore = m_data.moves[i].score;
+				}
+			}
+
+			if (best != m_idx)
+				std::swap(m_data.moves[m_idx], m_data.moves[best]);
+			 */
+
+			return m_idx++;
+		}
+
+		const Position &m_pos;
+
+		i32 m_stage{MovegenStage::Start};
+
+		MovegenData &m_data;
+		u32 m_idx{};
+	};
+
+	template <bool Root>
+	[[nodiscard]] static inline auto mainMoveGenerator(const Position &pos, MovegenData &data)
+	{
+		return MoveGenerator<Root, false>(pos, data);
+	}
+
+	[[nodiscard]] static inline auto qsearchMoveGenerator(const Position &pos, MovegenData &data)
+	{
+		return MoveGenerator<false, true>(pos, data);
+	}
+}

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -23,7 +23,6 @@
 #include <cassert>
 
 #include "uci.h"
-#include "movegen.h"
 #include "limit/trivial.h"
 #include "opts.h"
 #include "3rdparty/fathom/tbprobe.h"
@@ -415,7 +414,7 @@ namespace stormphrax::search
 		auto bestMove = NullMove;
 		auto bestScore = -ScoreInf;
 
-		MoveGenerator<RootNode> generator{pos, moveStack.movegenData};
+		auto generator = mainMoveGenerator<RootNode>(pos, moveStack.movegenData);
 
 		u32 legalMoves = 0;
 

--- a/src/search.h
+++ b/src/search.h
@@ -38,7 +38,7 @@
 #include "util/timer.h"
 #include "ttable.h"
 #include "eval/eval.h"
-#include "movegen.h"
+#include "movepick.h"
 #include "util/barrier.h"
 
 namespace stormphrax::search


### PR DESCRIPTION
```
Elo   | 284.16 +- 73.73 (95%)
SPRT  | 36.0+0.36s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 10.00]
Games | N: 184 W: 148 L: 24 D: 12
Penta | [1, 1, 22, 9, 59]
```
https://chess.swehosting.se/test/6129/