### PR TITLE
score noisy moves by mvv-lva 

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -87,6 +87,13 @@ namespace stormphrax
 		return static_cast<PieceType>(static_cast<i32>(piece) >> 1);
 	}
 
+	[[nodiscard]] constexpr auto pieceTypeOrNone(Piece piece)
+	{
+		if (piece == Piece::None)
+			return PieceType::None;
+		return static_cast<PieceType>(static_cast<i32>(piece) >> 1);
+	}
+
 	[[nodiscard]] constexpr auto pieceColor(Piece piece)
 	{
 		assert(piece != Piece::None);

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -68,13 +68,11 @@ namespace stormphrax
 			{
 				while (m_idx == m_data.moves.size())
 				{
-					++m_stage;
-
-					switch (m_stage)
+					switch (++m_stage)
 					{
 						case MovegenStage::Noisy:
 							generateNoisy(m_data.moves, m_pos);
-							scoreNoisies();
+							scoreNoisy();
 							if constexpr (NoisiesOnly)
 								m_stage = MovegenStage::End;
 							break;
@@ -98,7 +96,7 @@ namespace stormphrax
 		[[nodiscard]] inline auto stage() const { return m_stage; }
 
 	private:
-		inline auto scoreNoisy(const PositionBoards &boards, ScoredMove &scoredMove)
+		inline auto scoreSingleNoisy(const PositionBoards &boards, ScoredMove &scoredMove)
 		{
 			const auto move = scoredMove.move;
 			auto &score = scoredMove.score;
@@ -113,12 +111,12 @@ namespace stormphrax
 			score += see::value(captured) * 4000;
 		}
 
-		inline auto scoreNoisies() -> void
+		inline auto scoreNoisy() -> void
 		{
 			const auto &boards = m_pos.boards();
 			for (u32 i = m_idx; i < m_data.moves.size(); ++i)
 			{
-				scoreNoisy(boards, m_data.moves[i]);
+				scoreSingleNoisy(boards, m_data.moves[i]);
 			}
 		}
 
@@ -132,7 +130,7 @@ namespace stormphrax
 				if (m_pos.isNoisy(move.move))
 				{
 					move.score += 16000000;
-					scoreNoisy(boards, move);
+					scoreSingleNoisy(boards, move);
 				}
 			}
 		}


### PR DESCRIPTION
```
Elo   | 40.97 +- 22.18 (95%)
SPRT  | 34.0+0.34s Threads=1 Hash=32MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 10.00]
Games | N: 852 W: 425 L: 325 D: 102
Penta | [47, 31, 209, 53, 86]
```
https://chess.swehosting.se/test/6132/