### PR TITLE
PVS

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -357,8 +357,7 @@ namespace stormphrax::search
 		const auto us = pos.toMove();
 		const auto them = oppColor(us);
 
-		// placeholder
-		const bool pvNode = true;
+		const bool pvNode = beta - alpha > 1;
 
 		auto &stack = thread.stack[ply];
 		auto &moveStack = thread.moveStack[moveStackIdx];
@@ -440,7 +439,15 @@ namespace stormphrax::search
 			else
 			{
 				const auto newDepth = depth - 1;
-				score = -search(thread, stack.pv, newDepth, ply + 1, moveStackIdx + 1, -beta, -alpha);
+
+				if (legalMoves == 1)
+					score = -search(thread, stack.pv, newDepth, ply + 1, moveStackIdx + 1, -beta, -alpha);
+				else
+				{
+					score = -search(thread, stack.pv, newDepth, ply + 1, moveStackIdx + 1, -alpha - 1, -alpha);
+					if (score > alpha && score < beta)
+						score = -search(thread, stack.pv, newDepth, ply + 1, moveStackIdx + 1, -beta, -alpha);
+				}
 			}
 
 			if constexpr (RootNode)


### PR DESCRIPTION
```
Elo   | 23.62 +- 16.42 (95%)
SPRT  | 32.0+0.32s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 10.00]
Games | N: 1532 W: 728 L: 624 D: 180
Penta | [88, 78, 381, 80, 139]
```
https://chess.swehosting.se/test/6140/