### PR TITLE
don't overwrite TT moves from the same position when we failed low

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -422,6 +422,8 @@ namespace stormphrax::search
 			}
 		}
 
+		const auto originalAlpha = alpha;
+
 		auto bestMove = NullMove;
 		auto bestScore = -ScoreInf;
 
@@ -510,7 +512,10 @@ namespace stormphrax::search
 		bestScore = std::clamp(bestScore, syzygyMin, syzygyMax);
 
 		if (!shouldStop(thread.search, false, false))
-			m_ttable.put(pos.key(), bestScore, bestMove, depth, ply, ttFlag);
+		{
+			const auto newTtMove = alpha > originalAlpha ? bestMove : NullMove;
+			m_ttable.put(pos.key(), bestScore, newTtMove, depth, ply, ttFlag);
+		}
 
 		return bestScore;
 	}

--- a/src/ttable.cpp
+++ b/src/ttable.cpp
@@ -103,16 +103,18 @@ namespace stormphrax
 
 		auto entry = loadEntry(index(key));
 
-		const auto entryKey = packEntryKey(key);
+		const auto newKey = packEntryKey(key);
 
 #ifndef NDEBUG
 		if (std::abs(score) > std::numeric_limits<i16>::max())
 			std::cerr << "trying to put out of bounds score " << score << " into ttable" << std::endl;
 #endif
 
-		entry.key = entryKey;
+		if (move || entry.key != newKey)
+			entry.move = move;
+
+		entry.key = newKey;
 		entry.score = static_cast<i16>(scoreToTt(score, ply));
-		entry.move = move;
 		entry.depth = depth;
 		entry.flag = flag;
 


### PR DESCRIPTION
```
Elo   | 26.75 +- 12.58 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2590 W: 1234 L: 1035 D: 321
Penta | [178, 116, 594, 143, 264]
```
https://chess.swehosting.se/test/6191/