### PR TITLE
history penalty for moves that do not raise alpha

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -429,8 +429,8 @@ namespace stormphrax::search
 			}
 		}
 
-		auto &quietsTried = thread.moveStack[moveStackIdx].quietsTried;
-		quietsTried.clear();
+		auto &failLowQuiets = thread.moveStack[moveStackIdx].failLowQuiets;
+		failLowQuiets.clear();
 
 		const auto originalAlpha = alpha;
 
@@ -515,8 +515,8 @@ namespace stormphrax::search
 				}
 			}
 
-			if (!pos.isNoisy(move))
-				quietsTried.push(move);
+			if (move != bestMove && !pos.isNoisy(move))
+				failLowQuiets.push(move);
 		}
 
 		if (legalMoves == 0)
@@ -527,10 +527,9 @@ namespace stormphrax::search
 			const auto bonus = historyBonus(depth);
 			const auto penalty = -bonus;
 
-			if (bestScore >= beta)
-				thread.history.updateQuietScore(bestMove, bonus);
+			thread.history.updateQuietScore(bestMove, bonus);
 
-			for (const auto prevQuiet : quietsTried)
+			for (const auto prevQuiet : failLowQuiets)
 			{
 				thread.history.updateQuietScore(prevQuiet, penalty);
 			}

--- a/src/search.h
+++ b/src/search.h
@@ -76,6 +76,7 @@ namespace stormphrax::search
 	struct MoveStackEntry
 	{
 		MovegenData movegenData{};
+		StaticVector<Move, 256> quietsTried{};
 	};
 
 	struct alignas(SP_CACHE_LINE_SIZE) ThreadData

--- a/src/search.h
+++ b/src/search.h
@@ -76,7 +76,7 @@ namespace stormphrax::search
 	struct MoveStackEntry
 	{
 		MovegenData movegenData{};
-		StaticVector<Move, 256> quietsTried{};
+		StaticVector<Move, 256> failLowQuiets{};
 	};
 
 	struct alignas(SP_CACHE_LINE_SIZE) ThreadData


### PR DESCRIPTION
```
Elo   | 9.65 +- 8.37 (95%)
SPRT  | 28.0+0.28s Threads=1 Hash=32MB
LLR   | 3.05 (-2.94, 2.94) [0.00, 10.00]
Games | N: 5620 W: 2466 L: 2310 D: 844
Penta | [370, 334, 1314, 354, 438]
```
https://chess.swehosting.se/test/6197/