### PR TITLE
basic log LMR

### DIFF
--- a/src/bench.h
+++ b/src/bench.h
@@ -27,7 +27,7 @@ namespace stormphrax::bench
 #ifdef SP_PGO_PROFILE
 	constexpr i32 DefaultBenchDepth = 3;
 #else
-	constexpr i32 DefaultBenchDepth = 6;
+	constexpr i32 DefaultBenchDepth = 8;
 #endif
 
 	constexpr usize DefaultBenchTtSize = 16;

--- a/src/tunable.cpp
+++ b/src/tunable.cpp
@@ -18,10 +18,30 @@
 
 #include "tunable.h"
 
+#include <cmath>
+
 namespace stormphrax::tunable
 {
+	std::array<std::array<i32, 256>, 256> g_lmrTable{};
+
+	auto updateLmrTable() -> void
+	{
+		const auto base = static_cast<f64>(lmrBase()) / 100.0;
+		const auto divisor = static_cast<f64>(lmrDivisor()) / 100.0;
+
+		for (i32 depth = 1; depth < 256; ++depth)
+		{
+			for (i32 moves = 1; moves < 256; ++moves)
+			{
+				g_lmrTable[depth][moves] = static_cast<i32>(
+					base + std::log(static_cast<f64>(depth)) * std::log(static_cast<f64>(moves)) / divisor
+				);
+			}
+		}
+	}
+
 	auto init() -> void
 	{
-		//
+		updateLmrTable();
 	}
 }

--- a/src/tunable.h
+++ b/src/tunable.h
@@ -34,6 +34,9 @@ namespace stormphrax::tunable
 {
 	auto init() -> void;
 
+	extern std::array<std::array<i32, 256>, 256> g_lmrTable;
+	auto updateLmrTable() -> void;
+
 #define SP_TUNABLE_ASSERTS(Default, Min, Max, Step) \
 	static_assert(Default >= Min); \
 	static_assert(Default <= Max); \
@@ -88,6 +91,9 @@ namespace stormphrax::tunable
 	SP_TUNABLE_PARAM(maxHistoryBonus, 2300, 1024, 3072, 256)
 	SP_TUNABLE_PARAM(historyBonusDepthScale, 300, 128, 512, 32)
 	SP_TUNABLE_PARAM(historyBonusOffset, 300, 128, 768, 64)
+
+	SP_TUNABLE_PARAM_CALLBACK(lmrBase, 77, 50, 120, 5, updateLmrTable)
+	SP_TUNABLE_PARAM_CALLBACK(lmrDivisor, 226, 100, 300, 10, updateLmrTable)
 
 	SP_TUNABLE_PARAM(qsearchSeeThreshold, -105, -2000, 200, 100)
 


### PR DESCRIPTION
```
Elo   | 345.15 +- 86.12 (95%)
SPRT  | 27.0+0.27s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 10.00]
Games | N: 170 W: 142 L: 13 D: 15
Penta | [0, 1, 12, 14, 58]
```
https://chess.swehosting.se/test/6199/