### PR TITLE
lmr more in non-pv nodes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -477,7 +477,11 @@ namespace stormphrax::search
 							|| generator.stage() < MovegenStage::Quiet)
 							return 0;
 
-						return g_lmrTable[depth][legalMoves];
+						auto r =  g_lmrTable[depth][legalMoves];
+
+						r += !pvNode;
+
+						return r;
 					}();
 
 					const auto reduced = std::clamp(newDepth - reduction, 0, newDepth);


### PR DESCRIPTION
```
Elo   | 79.80 +- 29.19 (95%)
SPRT  | 27.0+0.27s Threads=1 Hash=32MB
LLR   | 3.05 (-2.94, 2.94) [0.00, 10.00]
Games | N: 412 W: 192 L: 99 D: 121
Penta | [10, 24, 70, 67, 35]
```
https://chess.swehosting.se/test/6202/