### PR TITLE
normal aspiration windows

### DIFF
--- a/src/tunable.h
+++ b/src/tunable.h
@@ -88,6 +88,7 @@ namespace stormphrax::tunable
 
 	SP_TUNABLE_PARAM(minAspDepth, 5, 1, 10, 1)
 	SP_TUNABLE_PARAM(initialAspWindow, 30, 4, 50, 4)
+	SP_TUNABLE_PARAM(aspWideningFactor, 16, 1, 24, 1)
 
 	SP_TUNABLE_PARAM(maxHistory, 16384, 8192, 32768, 256)
 


### PR DESCRIPTION
```
Elo   | 72.22 +- 27.33 (95%)
SPRT  | 27.0+0.27s Threads=1 Hash=32MB
LLR   | 3.06 (-2.94, 2.94) [0.00, 10.00]
Games | N: 366 W: 141 L: 66 D: 159
Penta | [1, 25, 73, 66, 18]
```
https://chess.swehosting.se/test/6206/