### PR TITLE
more nmp reduction at higher depths

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -479,7 +479,7 @@ namespace stormphrax::search
 				&& !thread.stack[ply - 1].move.isNull()
 				&& !bbs.nonPk(us).empty())
 			{
-				constexpr auto R = nmpBaseReduction();
+				const auto R = nmpBaseReduction() + depth / 4;
 
 				stack.move = NullMove;
 				const auto guard = pos.applyNullMove();


### PR DESCRIPTION
```
Elo   | 30.44 +- 17.38 (95%)
SPRT  | 27.0+0.27s Threads=1 Hash=32MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 10.00]
Games | N: 904 W: 303 L: 224 D: 377
Penta | [13, 93, 179, 136, 31]
```
https://chess.swehosting.se/test/6234/