### PR TITLE
properly detect quiet moves for history

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -556,6 +556,8 @@ namespace stormphrax::search
 			else if (!pos.isLegal(move))
 				continue;
 
+			const bool noisy = pos.isNoisy(move);
+
 			if (pvNode)
 				curr.pv.length = 0;
 
@@ -643,7 +645,7 @@ namespace stormphrax::search
 				break;
 			}
 
-			if (move != bestMove && !pos.isNoisy(move))
+			if (move != bestMove && !noisy)
 				failLowQuiets.push(move);
 		}
 


### PR DESCRIPTION
```
Elo   | 33.05 +- 11.77 (95%)
SPRT  | 26.0+0.26s Threads=1 Hash=32MB
LLR   | 3.02 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 1666 W: 492 L: 334 D: 840
Penta | [18, 140, 369, 278, 28]
```
https://chess.swehosting.se/test/6263/