### PR TITLE
see pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -558,6 +558,16 @@ namespace stormphrax::search
 
 			const bool noisy = pos.isNoisy(move);
 
+			if (bestScore > -ScoreWin)
+			{
+				const auto seeThreshold = noisy
+					? -90 * depth
+					: -25 * depth * depth;
+
+				if (!see::see(pos, move, seeThreshold))
+					continue;
+			}
+
 			if (pvNode)
 				curr.pv.length = 0;
 


### PR DESCRIPTION
```
Elo   | 32.77 +- 18.51 (95%)
SPRT  | 24.0+0.24s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 10.00]
Games | N: 670 W: 196 L: 133 D: 341
Penta | [3, 55, 161, 108, 8]
```
https://chess.swehosting.se/test/6264/