### PR TITLE
forward futility pruning

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -76,8 +76,11 @@ namespace stormphrax
 							break;
 
 						case MovegenStage::Quiet:
-							generateQuiet(m_data.moves, m_pos);
-							scoreQuiet();
+							if (!m_skipQuiets)
+							{
+								generateQuiet(m_data.moves, m_pos);
+								scoreQuiet();
+							}
 							break;
 
 						default:
@@ -87,12 +90,20 @@ namespace stormphrax
 
 				assert(m_idx < m_data.moves.size());
 
+				if (m_skipQuiets && m_stage >= MovegenStage::Quiet)
+					return NullMove;
+
 				const auto idx = findNext();
 				const auto move = m_data.moves[idx].move;
 
 				if (move != m_ttMove)
 					return move;
 			}
+		}
+
+		inline auto skipQuiets()
+		{
+			m_skipQuiets = true;
 		}
 
 		[[nodiscard]] inline auto stage() const { return m_stage; }
@@ -174,6 +185,8 @@ namespace stormphrax
 		const Position &m_pos;
 
 		i32 m_stage{MovegenStage::Start};
+
+		bool m_skipQuiets{false};
 
 		const HistoryTables *m_history;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -494,11 +494,11 @@ namespace stormphrax::search
 			&& !ttEntry.move)
 			--depth;
 
+		const auto staticEval = eval::staticEval(pos, thread.nnueState, m_contempt);
+
 		if (!pvNode
 			&& !inCheck)
 		{
-			const auto staticEval = eval::staticEval(pos, thread.nnueState, m_contempt);
-
 			if (depth <= maxRfpDepth()
 				&& staticEval - rfpMargin() * depth >= beta)
 				return staticEval;
@@ -560,6 +560,15 @@ namespace stormphrax::search
 
 			if (bestScore > -ScoreWin)
 			{
+				if (!noisy
+					&& depth <= 8
+					&& std::abs(alpha) < 2000
+					&& staticEval + 250 + depth * 65 <= alpha)
+				{
+					generator.skipQuiets();
+					continue;
+				}
+
 				const auto seeThreshold = noisy
 					? seePruningThresholdNoisy() * depth
 					: seePruningThresholdQuiet() * depth * depth;


### PR DESCRIPTION
```
Elo   | 8.45 +- 7.82 (95%)
SPRT  | 25.0+0.25s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 10.00]
Games | N: 3538 W: 870 L: 784 D: 1884
Penta | [32, 382, 855, 468, 32]
```
https://chess.swehosting.se/test/6265/