### PR TITLE
replace mvv-lva with mvv + capthist

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -71,7 +71,8 @@ namespace stormphrax
 
 		inline auto clear()
 		{
-			std::memset(&m_main, 0, sizeof(m_main));
+			std::memset(&m_main , 0, sizeof(m_main ));
+			std::memset(&m_noisy, 0, sizeof(m_noisy));
 		}
 
 		inline auto updateQuietScore(Move move, HistoryScore bonus)
@@ -80,12 +81,28 @@ namespace stormphrax
 			score.update(bonus);
 		}
 
+		inline auto updateNoisyScore(Move move, Piece captured, HistoryScore bonus)
+		{
+			auto &score = m_noisy[move.srcIdx()][move.dstIdx()][static_cast<i32>(captured)];
+			score.update(bonus);
+		}
+
 		[[nodiscard]] inline auto quietScore(Move move) const -> HistoryScore
 		{
 			return m_main[move.srcIdx()][move.dstIdx()];
 		}
 
+		[[nodiscard]] inline auto noisyScore(Move move, Piece captured) const -> HistoryScore
+		{
+			return m_noisy[move.srcIdx()][move.dstIdx()][static_cast<i32>(captured)];
+		}
+
 	private:
+		// [from][to]
 		std::array<std::array<HistoryEntry, 64>, 64> m_main{};
+
+		// [from][to][captured]
+		// additional slot for non-capture queen promos
+		std::array<std::array<std::array<HistoryEntry, 13>, 64>, 64> m_noisy{};
 	};
 }

--- a/src/search.h
+++ b/src/search.h
@@ -78,6 +78,7 @@ namespace stormphrax::search
 	{
 		MovegenData movegenData{};
 		StaticVector<Move, 256> failLowQuiets{};
+		StaticVector<Move, 32> failLowNoisies{};
 	};
 
 	struct alignas(SP_CACHE_LINE_SIZE) ThreadData


### PR DESCRIPTION
```
Elo   | 2.85 +- 2.82 (95%)
SPRT  | 24.0+0.24s Threads=1 Hash=32MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 27538 W: 6618 L: 6392 D: 14528
Penta | [212, 3253, 6631, 3443, 230]
```
https://chess.swehosting.se/test/6268/

doom emote