### PR TITLE
index butterfly history by whether the from- and to-squares are attacked

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -26,6 +26,7 @@
 
 #include "tunable.h"
 #include "move.h"
+#include "bitboard.h"
 
 namespace stormphrax
 {
@@ -75,9 +76,9 @@ namespace stormphrax
 			std::memset(&m_noisy, 0, sizeof(m_noisy));
 		}
 
-		inline auto updateQuietScore(Move move, HistoryScore bonus)
+		inline auto updateQuietScore(Bitboard threats, Move move, HistoryScore bonus)
 		{
-			auto &score = m_main[move.srcIdx()][move.dstIdx()];
+			auto &score = m_main[move.srcIdx()][move.dstIdx()][threats[move.src()]][threats[move.dst()]];
 			score.update(bonus);
 		}
 
@@ -87,9 +88,9 @@ namespace stormphrax
 			score.update(bonus);
 		}
 
-		[[nodiscard]] inline auto quietScore(Move move) const -> HistoryScore
+		[[nodiscard]] inline auto quietScore(Bitboard threats, Move move) const -> HistoryScore
 		{
-			return m_main[move.srcIdx()][move.dstIdx()];
+			return m_main[move.srcIdx()][move.dstIdx()][threats[move.src()]][threats[move.dst()]];
 		}
 
 		[[nodiscard]] inline auto noisyScore(Move move, Piece captured) const -> HistoryScore
@@ -98,8 +99,8 @@ namespace stormphrax
 		}
 
 	private:
-		// [from][to]
-		std::array<std::array<HistoryEntry, 64>, 64> m_main{};
+		// [from][to][from attacked][to attacked]
+		std::array<std::array<std::array<std::array<HistoryEntry, 2>, 2>, 64>, 64> m_main{};
 
 		// [from][to][captured]
 		// additional slot for non-capture queen promos

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -134,7 +134,7 @@ namespace stormphrax
 
 		inline auto scoreSingleQuiet(ScoredMove &move)
 		{
-			move.score = m_history.quietScore(move.move);
+			move.score = m_history.quietScore(m_pos.threats(), move.move);
 		}
 
 		inline auto scoreQuiet() -> void

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -682,11 +682,11 @@ namespace stormphrax::search
 
 			if (!pos.isNoisy(bestMove))
 			{
-				thread.history.updateQuietScore(bestMove, bonus);
+				thread.history.updateQuietScore(pos.threats(), bestMove, bonus);
 
 				for (const auto prevQuiet : moveStack.failLowQuiets)
 				{
-					thread.history.updateQuietScore(prevQuiet, penalty);
+					thread.history.updateQuietScore(pos.threats(), prevQuiet, penalty);
 				}
 			}
 			else


### PR DESCRIPTION
```
Elo   | 7.41 +- 5.77 (95%)
SPRT  | 22.0+0.22s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6472 W: 1577 L: 1439 D: 3456
Penta | [41, 731, 1561, 855, 48]
```
https://chess.swehosting.se/test/6284/