### PR TITLE
improving in lmp

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -582,7 +582,7 @@ namespace stormphrax::search
 						continue;
 					}
 
-					if (legalMoves >= 3 + depth * depth)
+					if (legalMoves >= (3 + depth * depth) / (2 - improving))
 					{
 						generator.skipQuiets();
 						continue;


### PR DESCRIPTION
```
Elo   | 8.09 +- 6.08 (95%)
SPRT  | 17.0+0.17s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6060 W: 1539 L: 1398 D: 3123
Penta | [56, 670, 1436, 813, 55]
```
https://chess.swehosting.se/test/6313/