### PR TITLE
prefetch TT entries

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -529,6 +529,8 @@ namespace stormphrax::search
 				&& !parent->move.isNull()
 				&& !bbs.nonPk(us).empty())
 			{
+				m_ttable.prefetch(pos.key() ^ keys::color());
+
 				const auto R = nmpBaseReduction()
 					+ depth / nmpDepthReductionDiv();
 
@@ -596,6 +598,8 @@ namespace stormphrax::search
 				if (!see::see(pos, move, seeThreshold))
 					continue;
 			}
+
+			m_ttable.prefetch(pos.roughKeyAfter(move));
 
 			if (pvNode)
 				curr.pv.length = 0;


### PR DESCRIPTION
```
Elo   | 16.27 +- 8.97 (95%)
SPRT  | 16.0+0.16s Threads=1 Hash=32MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2714 W: 703 L: 576 D: 1435
Penta | [17, 270, 669, 371, 30]
```
https://chess.swehosting.se/test/6323/