### PR TITLE
singular extensions

### DIFF
--- a/src/bench.h
+++ b/src/bench.h
@@ -27,7 +27,7 @@ namespace stormphrax::bench
 #ifdef SP_PGO_PROFILE
 	constexpr i32 DefaultBenchDepth = 3;
 #else
-	constexpr i32 DefaultBenchDepth = 16;
+	constexpr i32 DefaultBenchDepth = 14;
 #endif
 
 	constexpr usize DefaultBenchTtSize = 16;

--- a/src/search.h
+++ b/src/search.h
@@ -89,6 +89,8 @@ namespace stormphrax::search
 		Move move;
 
 		Score staticEval;
+
+		Move excluded{};
 	};
 
 	struct MoveStackEntry


### PR DESCRIPTION
```
Elo   | 9.46 +- 6.62 (95%)
SPRT  | 16.0+0.16s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5072 W: 1287 L: 1149 D: 2636
Penta | [45, 569, 1165, 717, 40]
```
https://chess.swehosting.se/test/6325/

in scaling we trust