### PR TITLE
double extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -563,6 +563,9 @@ namespace stormphrax::search
 			}
 		}
 
+		if constexpr (!RootNode)
+			curr.doubleExtensions = parent->doubleExtensions;
+
 		moveStack.failLowQuiets .clear();
 		moveStack.failLowNoisies.clear();
 
@@ -645,8 +648,19 @@ namespace stormphrax::search
 				curr.excluded = NullMove;
 
 				if (score < sBeta)
-					extension = 1;
+				{
+					if (!PvNode
+						&& score <= sBeta - 18
+						&& curr.doubleExtensions <= 8)
+					{
+						extension = 2;
+						++curr.doubleExtensions;
+					}
+					else extension = 1;
+				}
 			}
+
+			curr.doubleExtensions += extension >= 2;
 
 			m_ttable.prefetch(pos.roughKeyAfter(move));
 

--- a/src/search.h
+++ b/src/search.h
@@ -91,6 +91,8 @@ namespace stormphrax::search
 		Score staticEval;
 
 		Move excluded{};
+
+		i32 doubleExtensions{};
 	};
 
 	struct MoveStackEntry


### PR DESCRIPTION
```
Elo   | 22.31 +- 10.63 (95%)
SPRT  | 16.0+0.16s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1934 W: 517 L: 393 D: 1024
Penta | [11, 193, 441, 305, 17]
```
https://chess.swehosting.se/test/6373/