### PR TITLE
triple extensions when score is far below sbeta

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -400,7 +400,7 @@ namespace stormphrax::search
 	{
 		assert(ply >= 0 && ply <= MaxDepth);
 		assert(RootNode || ply > 0);
-		assert(!PvNode || alpha + 1 == beta);
+		assert(PvNode || alpha + 1 == beta);
 
 		if (ply > 0 && shouldStop(thread.search, thread.isMainThread(), false))
 			return 0;
@@ -457,6 +457,8 @@ namespace stormphrax::search
 					|| ttEntry.flag == TtFlag::LowerBound && ttEntry.score >= beta))
 				return ttEntry.score;
 		}
+
+		const bool ttMoveNoisy = ttEntry.move && pos.isNoisy(ttEntry.move);
 
 		const auto pieceCount = bbs.occupancy().popcount();
 
@@ -650,10 +652,10 @@ namespace stormphrax::search
 				if (score < sBeta)
 				{
 					if (!PvNode
-						&& score <= sBeta - doubleExtMargin()
+						&& score < sBeta - doubleExtMargin()
 						&& curr.doubleExtensions <= doubleExtLimit())
 					{
-						extension = 2;
+						extension = 2 + (!ttMoveNoisy && score < sBeta - 100);
 						++curr.doubleExtensions;
 					}
 					else extension = 1;

--- a/src/tunable.h
+++ b/src/tunable.h
@@ -120,7 +120,7 @@ namespace stormphrax::tunable
 	SP_TUNABLE_PARAM(seTtDepthMargin, 4, 2, 6, 1)
 	SP_TUNABLE_PARAM(sBetaMargin, 32, 4, 64, 12)
 
-	SP_TUNABLE_PARAM(doubleExtMargin, 18, 0, 32, 5)
+	SP_TUNABLE_PARAM(doubleExtMargin, 17, 0, 32, 5)
 	SP_TUNABLE_PARAM(doubleExtLimit, 8, 4, 24, 4)
 
 	SP_TUNABLE_PARAM(minLmrDepth, 2, 2, 5, 1)


### PR DESCRIPTION
```
Elo   | 4.35 +- 4.09 (95%)
SPRT  | 16.0+0.16s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 13412 W: 3336 L: 3168 D: 6908
Penta | [103, 1548, 3271, 1646, 138]
```
https://chess.swehosting.se/test/6377/