### PR TITLE
reduce bad noisy moves less

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -689,7 +689,7 @@ namespace stormphrax::search
 							|| generator.stage() < MovegenStage::Quiet)
 							return 0;
 
-						auto r =  g_lmrTable[depth][legalMoves];
+						auto r =  g_lmrTable[noisy][depth][legalMoves];
 
 						r += !PvNode;
 

--- a/src/tunable.cpp
+++ b/src/tunable.cpp
@@ -22,20 +22,47 @@
 
 namespace stormphrax::tunable
 {
-	std::array<std::array<i32, 256>, 256> g_lmrTable{};
-
-	auto updateLmrTable() -> void
+	namespace
 	{
-		const auto base = static_cast<f64>(lmrBase()) / 100.0;
-		const auto divisor = static_cast<f64>(lmrDivisor()) / 100.0;
+		inline auto lmrReduction(f64 base, f64 divisor, i32 depth, i32 moves)
+		{
+			const auto lnDepth = std::log(static_cast<f64>(depth));
+			const auto lnMoves = std::log(static_cast<f64>(moves));
+			return static_cast<i32>(base + lnDepth * lnMoves / divisor);
+		}
+
+		inline auto lmpMoveCount(i32 base, bool improving, i32 depth)
+		{
+			return (base + depth * depth) / (2 - improving);
+		}
+	}
+
+	std::array<std::array<std::array<i32, 256>, 256>, 2> g_lmrTable{};
+
+	auto updateQuietLmrTable() -> void
+	{
+		const auto base = static_cast<f64>(quietLmrBase()) / 100.0;
+		const auto divisor = static_cast<f64>(quietLmrDivisor()) / 100.0;
 
 		for (i32 depth = 1; depth < 256; ++depth)
 		{
 			for (i32 moves = 1; moves < 256; ++moves)
 			{
-				g_lmrTable[depth][moves] = static_cast<i32>(
-					base + std::log(static_cast<f64>(depth)) * std::log(static_cast<f64>(moves)) / divisor
-				);
+				g_lmrTable[0][depth][moves] = lmrReduction(base, divisor, depth, moves);
+			}
+		}
+	}
+
+	auto updateNoisyLmrTable() -> void
+	{
+		const auto base = static_cast<f64>(noisyLmrBase()) / 100.0;
+		const auto divisor = static_cast<f64>(noisyLmrDivisor()) / 100.0;
+
+		for (i32 depth = 1; depth < 256; ++depth)
+		{
+			for (i32 moves = 1; moves < 256; ++moves)
+			{
+				g_lmrTable[1][depth][moves] = lmrReduction(base, divisor, depth, moves);
 			}
 		}
 	}
@@ -50,14 +77,16 @@ namespace stormphrax::tunable
 		{
 			for (i32 depth = 0; depth < 16; ++depth)
 			{
-				g_lmpTable[improving][depth] = (base + depth * depth) / (2 - improving);
+				g_lmpTable[improving][depth] = lmpMoveCount(base, improving, depth);
 			}
 		}
 	}
 
 	auto init() -> void
 	{
-		updateLmrTable();
+		updateQuietLmrTable();
+		updateNoisyLmrTable();
+
 		updateLmpTable();
 	}
 }

--- a/src/tunable.h
+++ b/src/tunable.h
@@ -34,9 +34,11 @@ namespace stormphrax::tunable
 {
 	auto init() -> void;
 
-	// [depth][legal moves]
-	extern std::array<std::array<i32, 256>, 256> g_lmrTable;
-	auto updateLmrTable() -> void;
+	// [noisy][depth][legal moves]
+	extern std::array<std::array<std::array<i32, 256>, 256>, 2> g_lmrTable;
+
+	auto updateQuietLmrTable() -> void;
+	auto updateNoisyLmrTable() -> void;
 
 	// [improving][clamped depth]
 	extern std::array<std::array<i32, 16>, 2> g_lmpTable;
@@ -126,8 +128,11 @@ namespace stormphrax::tunable
 	SP_TUNABLE_PARAM(minLmrDepth, 2, 2, 5, 1)
 	SP_TUNABLE_PARAM(lmrMinMoves, 3, 0, 5, 1)
 
-	SP_TUNABLE_PARAM_CALLBACK(lmrBase, 77, 50, 120, 5, updateLmrTable)
-	SP_TUNABLE_PARAM_CALLBACK(lmrDivisor, 226, 100, 300, 10, updateLmrTable)
+	SP_TUNABLE_PARAM_CALLBACK(quietLmrBase, 77, 50, 120, 15, updateQuietLmrTable)
+	SP_TUNABLE_PARAM_CALLBACK(quietLmrDivisor, 226, 100, 300, 10, updateQuietLmrTable)
+
+	SP_TUNABLE_PARAM_CALLBACK(noisyLmrBase, 0, -50, 75, 10, updateNoisyLmrTable)
+	SP_TUNABLE_PARAM_CALLBACK(noisyLmrDivisor, 250, 150, 350, 10, updateNoisyLmrTable)
 
 	SP_TUNABLE_PARAM(maxHistory, 16384, 8192, 32768, 256)
 


### PR DESCRIPTION
```
Elo   | 7.95 +- 6.17 (95%)
SPRT  | 14.0+0.14s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 5942 W: 1521 L: 1385 D: 3036
Penta | [40, 670, 1436, 764, 61]
```
https://chess.swehosting.se/test/6433/