### PR TITLE
persist history between searches

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -318,8 +318,6 @@ namespace stormphrax::search
 			return -ScoreMate;
 		}
 
-		thread.history.clear();
-
 		const auto waitForThreads = [&]
 		{
 			--m_runningThreads;


### PR DESCRIPTION
```
Elo   | 15.23 +- 8.80 (95%)
SPRT  | 14.0+0.14s Threads=1 Hash=32MB
LLR   | 3.00 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2990 W: 812 L: 681 D: 1497
Penta | [27, 301, 715, 418, 34]
```
https://chess.swehosting.se/test/6442/