### PR TITLE
adjust lmr by history

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -597,6 +597,12 @@ namespace stormphrax::search
 			const bool noisy = pos.isNoisy(move);
 			const auto moving = boards.pieceAt(move.src());
 
+			const auto captured = pos.captureTarget(move);
+
+			const auto history = noisy
+				? thread.history.noisyScore(move, captured)
+				: thread.history.quietScore(thread.conthist, ply, pos.threats(), moving, move);
+
 			if (bestScore > -ScoreWin)
 			{
 				if (!noisy)
@@ -606,8 +612,6 @@ namespace stormphrax::search
 						generator.skipQuiets();
 						continue;
 					}
-
-					const auto history = thread.history.quietScore(thread.conthist, ply, pos.threats(), moving, move);
 
 					if (depth <= maxHistoryPruningDepth()
 						&& history < historyPruningMargin() * depth)
@@ -701,6 +705,7 @@ namespace stormphrax::search
 						auto r =  g_lmrTable[noisy][depth][legalMoves];
 
 						r += !PvNode;
+						r -= history / 8192;
 
 						return r;
 					}();


### PR DESCRIPTION
```
Elo   | 4.69 +- 4.36 (95%)
SPRT  | 14.0+0.14s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 12234 W: 3162 L: 2997 D: 6075
Penta | [103, 1447, 2893, 1530, 144]
```
https://chess.swehosting.se/test/6455/