### PR TITLE
stop double counting double extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -582,7 +582,7 @@ namespace stormphrax::search
 		}
 
 		if constexpr (!RootNode)
-			curr.doubleExtensions = parent->doubleExtensions;
+			curr.multiExtensions = parent->multiExtensions;
 
 		moveStack.failLowQuiets .clear();
 		moveStack.failLowNoisies.clear();
@@ -682,18 +682,13 @@ namespace stormphrax::search
 
 				if (score < sBeta)
 				{
-					if (!PvNode
-						&& score < sBeta - doubleExtMargin()
-						&& curr.doubleExtensions <= doubleExtLimit())
-					{
-						extension = 2 + (!ttMoveNoisy && score < sBeta - 100);
-						++curr.doubleExtensions;
-					}
+					if (!PvNode && curr.multiExtensions <= multiExtLimit() && score < sBeta - doubleExtMargin())
+						extension = 2 + (!ttMoveNoisy && score < sBeta - tripleExtMargin());
 					else extension = 1;
 				}
 			}
 
-			curr.doubleExtensions += extension >= 2;
+			curr.multiExtensions += extension >= 2;
 
 			m_ttable.prefetch(pos.roughKeyAfter(move));
 

--- a/src/search.h
+++ b/src/search.h
@@ -94,7 +94,7 @@ namespace stormphrax::search
 
 		Move excluded{};
 
-		i32 doubleExtensions{};
+		i32 multiExtensions{};
 	};
 
 	struct MoveStackEntry

--- a/src/tunable.h
+++ b/src/tunable.h
@@ -125,8 +125,10 @@ namespace stormphrax::tunable
 	SP_TUNABLE_PARAM(seTtDepthMargin, 4, 2, 6, 1)
 	SP_TUNABLE_PARAM(sBetaMargin, 32, 4, 64, 12)
 
+	SP_TUNABLE_PARAM(multiExtLimit, 8, 4, 24, 4)
+
 	SP_TUNABLE_PARAM(doubleExtMargin, 17, 0, 32, 5)
-	SP_TUNABLE_PARAM(doubleExtLimit, 8, 4, 24, 4)
+	SP_TUNABLE_PARAM(tripleExtMargin, 100, 10, 150, 7)
 
 	SP_TUNABLE_PARAM(minLmrDepth, 2, 2, 5, 1)
 	SP_TUNABLE_PARAM(lmrMinMoves, 3, 0, 5, 1)


### PR DESCRIPTION
```
Elo   | 0.63 +- 2.35 (95%)
SPRT  | 14.0+0.14s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 40896 W: 10014 L: 9940 D: 20942
Penta | [288, 4887, 10076, 4857, 340]
```
https://chess.swehosting.se/test/6458/

neutral as expected