### PR TITLE
multicut

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -638,6 +638,8 @@ namespace stormphrax::search
 
 				if (score < sBeta)
 					extension = 1;
+				else if (sBeta >= beta)
+					return sBeta;
 			}
 
 			m_ttable.prefetch(pos.roughKeyAfter(move));


### PR DESCRIPTION
```
Elo   | 9.09 +- 6.51 (95%)
SPRT  | 14.0+0.14s Threads=1 Hash=32MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 5.00]
Games | N: 5240 W: 1326 L: 1189 D: 2725
Penta | [39, 584, 1253, 689, 55]
```
https://chess.swehosting.se/test/6466/