### PR TITLE
detect upcoming repetitions in search

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -418,6 +418,13 @@ namespace stormphrax::search
 
 			if (alpha >= beta)
 				return alpha;
+
+			if (alpha < 0 && pos.hasCycle(ply))
+			{
+				alpha = drawScore(thread.search.nodes);
+				if (alpha >= beta)
+					return alpha;
+			}
 		}
 
 		const bool inCheck = pos.isCheck();
@@ -832,6 +839,13 @@ namespace stormphrax::search
 
 		if (ply >= MaxDepth)
 			return eval::staticEval(pos, thread.nnueState, m_contempt);
+
+		if (alpha < 0 && pos.hasCycle(ply))
+		{
+			alpha = drawScore(thread.search.nodes);
+			if (alpha >= beta)
+				return alpha;
+		}
 
 		if (ply > thread.search.seldepth)
 			thread.search.seldepth = ply;


### PR DESCRIPTION
```
Elo   | 16.04 +- 8.99 (95%)
SPRT  | 14.0+0.14s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2710 W: 702 L: 577 D: 1431
Penta | [19, 279, 643, 386, 28]
```
https://chess.swehosting.se/test/6503/