### PR TITLE
don't drop into qsearch from lmr

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -744,7 +744,7 @@ namespace stormphrax::search
 					}();
 
 					// can't use std::clamp because newDepth can be <0
-					const auto reduced = std::min(std::max(newDepth - reduction, 0), newDepth);
+					const auto reduced = std::min(std::max(newDepth - reduction, 1), newDepth);
 					score = -search(thread, curr.pv, reduced, ply + 1, moveStackIdx + 1, -alpha - 1, -alpha, true);
 
 					if (score > alpha && reduced < newDepth)


### PR DESCRIPTION
```
Elo   | 3.00 +- 2.42 (95%)
SPRT  | 14.0+0.14s Threads=1 Hash=32MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 5.00]
Games | N: 24076 W: 5710 L: 5502 D: 12864
Penta | [176, 2830, 5826, 3022, 184]
```
https://chess.swehosting.se/test/6561/

penta error bars start here