### PR TITLE
switch to a more conventional PVS impl

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -269,12 +269,12 @@ namespace stormphrax::search
 
 		auto searchRoot(ThreadData &thread, bool mainSearchThread) -> Score;
 
-		template <bool RootNode = false, bool PvNode = false>
+		template <bool PvNode = false, bool RootNode = false>
 		auto search(ThreadData &thread, PvList &pv, i32 depth,
 			i32 ply, u32 moveStackIdx, Score alpha, Score beta, bool cutnode) -> Score;
 
 		template <>
-		auto search<true, false>(ThreadData &thread, PvList &pv, i32 depth,
+		auto search<false, true>(ThreadData &thread, PvList &pv, i32 depth,
 			i32 ply, u32 moveStackIdx, Score alpha, Score beta, bool cutnode) -> Score = delete;
 
 		auto qsearch(ThreadData &thread, i32 ply, u32 moveStackIdx, Score alpha, Score beta) -> Score;


### PR DESCRIPTION
```
Elo   | 5.88 +- 4.31 (95%)
SPRT  | 14.0+0.14s Threads=1 Hash=32MB
LLR   | 2.94 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 7620 W: 1865 L: 1736 D: 4019
Penta | [53, 872, 1848, 967, 70]
```
https://chess.swehosting.se/test/6578/