### PR TITLE
store static eval in the TT

### DIFF
--- a/src/ttable.cpp
+++ b/src/ttable.cpp
@@ -93,6 +93,7 @@ namespace stormphrax
 			&& packEntryKey(key) == entry.key)
 		{
 			dst.score = scoreFromTt(static_cast<Score>(entry.score), ply);
+			dst.staticEval = static_cast<Score>(entry.staticEval);
 			dst.depth = entry.depth;
 			dst.move = entry.move;
 			dst.flag = entry.flag();
@@ -100,7 +101,7 @@ namespace stormphrax
 		else dst.flag = TtFlag::None;
 	}
 
-	auto TTable::put(u64 key, Score score, Move move, i32 depth, i32 ply, TtFlag flag) -> void
+	auto TTable::put(u64 key, Score score, Score staticEval, Move move, i32 depth, i32 ply, TtFlag flag) -> void
 	{
 		assert(depth >= 0);
 		assert(depth <= MaxDepth);
@@ -126,6 +127,7 @@ namespace stormphrax
 
 		entry.key = newKey;
 		entry.score = static_cast<i16>(scoreToTt(score, ply));
+		entry.staticEval = static_cast<i16>(staticEval);
 		entry.depth = depth;
 		entry.setAgeAndFlag(m_age, flag);
 

--- a/src/ttable.h
+++ b/src/ttable.h
@@ -44,6 +44,7 @@ namespace stormphrax
 	struct ProbedTTableEntry
 	{
 		Score score;
+		Score staticEval;
 		i32 depth;
 		Move move;
 		TtFlag flag;
@@ -58,7 +59,7 @@ namespace stormphrax
 		auto resize(usize size) -> void;
 
 		auto probe(ProbedTTableEntry &dst, u64 key, i32 ply) const -> void;
-		auto put(u64 key, Score score, Move move, i32 depth, i32 ply, TtFlag flag) -> void;
+		auto put(u64 key, Score score, Score staticEval, Move move, i32 depth, i32 ply, TtFlag flag) -> void;
 
 		inline auto age()
 		{
@@ -81,6 +82,7 @@ namespace stormphrax
 		{
 			u16 key;
 			i16 score;
+			i16 staticEval;
 			Move move;
 			u8 depth;
 			u8 ageAndFlag;
@@ -102,7 +104,7 @@ namespace stormphrax
 			}
 		};
 
-		static_assert(sizeof(Entry) == 8);
+		static_assert(sizeof(Entry) == 10);
 
 		[[nodiscard]] inline auto index(u64 key) const -> u64
 		{


### PR DESCRIPTION
```
Elo   | 2.47 +- 2.00 (95%)
SPRT  | 14.0+0.14s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 35250 W: 8467 L: 8216 D: 18567
Penta | [267, 4174, 8500, 4409, 275]
```
https://chess.swehosting.se/test/6581/