### PR TITLE
don't probe TBs or store to the TT in a singularity search

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -479,6 +479,7 @@ namespace stormphrax::search
 		// Probe the Syzygy tablebases for a WDL result
 		// if there are few enough pieces left on the board
 		if (!RootNode
+			&& !curr.excluded
 			&& g_opts.syzygyEnabled
 			&& pieceCount <= syzygyPieceLimit
 			&& (pieceCount < syzygyPieceLimit || depth >= g_opts.syzygyProbeDepth)
@@ -835,7 +836,7 @@ namespace stormphrax::search
 
 		bestScore = std::clamp(bestScore, syzygyMin, syzygyMax);
 
-		if (!shouldStop(thread.search, false, false))
+		if (!curr.excluded && !shouldStop(thread.search, false, false))
 			m_ttable.put(pos.key(), bestScore, curr.staticEval, bestMove, depth, ply, ttFlag);
 
 		return bestScore;


### PR DESCRIPTION
```
Elo   | 1.07 +- 2.17 (95%)
SPRT  | 14.0+0.14s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 29872 W: 7172 L: 7080 D: 15620
Penta | [217, 3608, 7213, 3662, 236]
```
https://chess.swehosting.se/test/6593/