### PR TITLE
re-enable node tm

### DIFF
--- a/src/limit/time.cpp
+++ b/src/limit/time.cpp
@@ -74,7 +74,6 @@ namespace stormphrax::limit
 		assert(bestMove != NullMove);
 		assert(totalNodes > 0);
 
-		/*
 		const auto nodeBase = static_cast<f64>(nodeTimeBase()) / 100.0;
 		const auto nodeScale = static_cast<f64>(nodeTimeScale()) / 100.0;
 
@@ -87,7 +86,6 @@ namespace stormphrax::limit
 		const auto moveNodeScale = std::max((nodeBase - bestMoveNodeFraction) * nodeScale, nodeMin);
 
 		m_scale = std::max(moveNodeScale, minScale);
-		 */
 	}
 
 	auto TimeManager::updateMoveNodes(Move move, usize nodes) -> void


### PR DESCRIPTION
```
Elo   | 11.52 +- 6.05 (95%)
SPRT  | 14.0+0.14s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3832 W: 968 L: 841 D: 2023
Penta | [25, 410, 927, 521, 33]
```
https://chess.swehosting.se/test/6608/
```
Elo   | 20.83 +- 7.94 (95%)
SPRT  | 70.0+0.70s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1770 W: 460 L: 354 D: 956
Penta | [3, 149, 478, 249, 6]
```
https://chess.swehosting.se/test/6610/

scalimg