### PR TITLE
cutoff from and store to the TT in qsearch

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -289,6 +289,7 @@ namespace stormphrax::search
 		auto search<false, true>(ThreadData &thread, PvList &pv, i32 depth, i32 ply,
 			u32 moveStackIdx, Score alpha, Score beta, bool cutnode) -> Score = delete;
 
+		template <bool PvNode = false>
 		auto qsearch(ThreadData &thread, i32 ply, u32 moveStackIdx, Score alpha, Score beta) -> Score;
 
 		auto report(const ThreadData &mainThread, const PvList &pv, i32 depth,


### PR DESCRIPTION
```
Elo   | 17.89 +- 7.87 (95%)
SPRT  | 14.0+0.14s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2430 W: 654 L: 529 D: 1247
Penta | [16, 257, 558, 354, 30]
```
https://chess.swehosting.se/test/6632/