### PR TITLE
qsearch futility pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -654,6 +654,8 @@ namespace stormphrax::search
 				alpha = staticEval;
 		}
 
+		const auto futility = staticEval + 150;
+
 		auto bestScore = staticEval;
 
 		auto generator = qsearchMoveGenerator(pos, thread.moveStack[moveStackIdx].movegenData);
@@ -662,6 +664,15 @@ namespace stormphrax::search
 		{
 			if (!pos.isLegal(move))
 				continue;
+
+			if (!pos.isCheck()
+				&& futility <= alpha
+				&& !see::see(pos, move, 1))
+			{
+				if (bestScore < futility)
+					bestScore = futility;
+				continue;
+			}
 
 			if (!see::see(pos, move, qsearchSeeThreshold()))
 				continue;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -898,7 +898,7 @@ namespace stormphrax::search
 				alpha = eval;
 		}
 
-		const auto futility = eval + 150;
+		const auto futility = eval + qsearchFpMargin();
 
 		auto bestMove = NullMove;
 		auto bestScore = eval;

--- a/src/tunable.h
+++ b/src/tunable.h
@@ -150,6 +150,7 @@ namespace stormphrax::tunable
 	SP_TUNABLE_PARAM(historyBonusDepthScale, 300, 128, 512, 32)
 	SP_TUNABLE_PARAM(historyBonusOffset, 300, 128, 768, 64)
 
+	SP_TUNABLE_PARAM(qsearchFpMargin, 150, 50, 400, 17)
 	SP_TUNABLE_PARAM(qsearchSeeThreshold, -105, -2000, 200, 100)
 
 #undef SP_TUNABLE_PARAM


### PR DESCRIPTION
```
Elo   | 7.93 +- 4.84 (95%)
SPRT  | 14.0+0.14s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 5786 W: 1443 L: 1311 D: 3032
Penta | [40, 613, 1462, 731, 47]
```
https://chess.swehosting.se/test/6642/