### PR TITLE
use tt score as eval in qsearch

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -889,7 +889,12 @@ namespace stormphrax::search
 				staticEval = ttEntry.staticEval;
 			else staticEval = eval::staticEval(pos, thread.nnueState, m_contempt);
 
-			eval = staticEval;
+			if (ttEntry.flag != TtFlag::None
+				&& (ttEntry.flag == TtFlag::Exact
+					|| ttEntry.flag == TtFlag::UpperBound && ttEntry.score < staticEval
+					|| ttEntry.flag == TtFlag::LowerBound && ttEntry.score > staticEval))
+				eval = ttEntry.score;
+			else eval = staticEval;
 
 			if (eval >= beta)
 				return eval;


### PR DESCRIPTION
```
Elo   | 3.56 +- 2.82 (95%)
SPRT  | 14.0+0.14s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 17474 W: 4202 L: 4023 D: 9249
Penta | [123, 2046, 4211, 2243, 114]
```
https://chess.swehosting.se/test/6647/