### PR TITLE
update conthist after unreduced lmr re-search

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -112,13 +112,18 @@ namespace stormphrax
 			return m_continuation[static_cast<i32>(moving)][static_cast<i32>(to)];
 		}
 
+		inline auto updateConthist(std::span<ContinuationSubtable *> continuations,
+			i32 ply, Piece moving, Move move, HistoryScore bonus)
+		{
+			updateConthist(continuations, ply, moving, move, bonus, 1);
+			updateConthist(continuations, ply, moving, move, bonus, 2);
+		}
+
 		inline auto updateQuietScore(std::span<ContinuationSubtable *> continuations,
 			i32 ply, Bitboard threats, Piece moving, Move move, HistoryScore bonus)
 		{
 			mainEntry(threats, move).update(bonus);
-
-			updateConthist(continuations, ply, moving, move, bonus, 1);
-			updateConthist(continuations, ply, moving, move, bonus, 2);
+			updateConthist(continuations, ply, moving, move, bonus);
 		}
 
 		inline auto updateNoisyScore(Move move, Piece captured, HistoryScore bonus)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -745,8 +745,16 @@ namespace stormphrax::search
 					score = -search(thread, curr.pv, reduced, ply + 1, moveStackIdx + 1, -alpha - 1, -alpha, true);
 
 					if (score > alpha && reduced < newDepth)
+					{
 						score = -search(thread, curr.pv, newDepth, ply + 1,
 							moveStackIdx + 1, -alpha - 1, -alpha, !cutnode);
+
+						if (!noisy && (score <= alpha || score >= beta))
+						{
+							const auto bonus = score <= alpha ? -historyBonus(newDepth) : historyBonus(newDepth);
+							thread.history.updateConthist(thread.conthist, ply, moving, move, bonus);
+						}
+					}
 				}
 				// if we're skipping LMR for some reason (first move in a non-PV
 				// node, or the conditions above for LMR were not met) then do an


### PR DESCRIPTION
```
Elo   | 6.90 +- 4.43 (95%)
SPRT  | 14.0+0.14s Threads=1 Hash=32MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 5.00]
Games | N: 7048 W: 1739 L: 1599 D: 3710
Penta | [42, 792, 1738, 888, 64]
```
https://chess.swehosting.se/test/6652/