### PR TITLE
more accidental bad noisy skippage

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -134,11 +134,7 @@ namespace stormphrax
 								m_end = m_data.moves.size();
 								scoreQuiet();
 							}
-							else
-							{
-								++m_stage;
-								continue;
-							}
+							else continue;
 							break;
 
 						case MovegenStage::BadNoisy:


### PR DESCRIPTION
```
Elo   | 2.18 +- 2.79 (95%)
SPRT  | 14.0+0.14s Threads=1 Hash=32MB
LLR   | 2.94 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 17888 W: 4300 L: 4188 D: 9400
Penta | [114, 2154, 4321, 2216, 139]
```
https://chess.swehosting.se/test/6658/