### PR TITLE
use LMR depth for quiet SEE pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -640,6 +640,8 @@ namespace stormphrax::search
 
 			const auto captured = pos.captureTarget(move);
 
+			const auto baseLmr =  g_lmrTable[noisy][depth][legalMoves + 1];
+
 			const auto history = noisy
 				? thread.history.noisyScore(move, captured)
 				: thread.history.quietScore(thread.conthist, ply, pos.threats(), moving, move);
@@ -672,9 +674,11 @@ namespace stormphrax::search
 					}
 				}
 
+				const auto lmrDepth = std::max(depth - baseLmr, 0);
+
 				const auto seeThreshold = noisy
 					? seePruningThresholdNoisy() * depth
-					: seePruningThresholdQuiet() * depth * depth;
+					: seePruningThresholdQuiet() * lmrDepth * lmrDepth;
 
 				if (quietOrLosing && !see::see(pos, move, seeThreshold))
 					continue;
@@ -735,7 +739,7 @@ namespace stormphrax::search
 					&& legalMoves >= lmrMinMoves()
 					&& quietOrLosing)
 				{
-					auto r =  g_lmrTable[noisy][depth][legalMoves];
+					auto r = baseLmr;
 
 					r += !PvNode;
 					r -= history / lmrHistoryDivisor();


### PR DESCRIPTION
```
Elo   | 5.68 +- 3.94 (95%)
SPRT  | 13.0+0.13s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8866 W: 2171 L: 2026 D: 4669
Penta | [60, 986, 2211, 1101, 75]
```
https://chess.swehosting.se/test/6659/