### PR TITLE
extend the entire node if tt bounds were wrong for a cutoff at low depth

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -471,7 +471,7 @@ namespace stormphrax::search
 					|| ttEntry.flag == TtFlag::UpperBound && ttEntry.score <= alpha
 					|| ttEntry.flag == TtFlag::LowerBound && ttEntry.score >= beta)
 					return ttEntry.score;
-				else ++depth;
+				else depth += depth < 7;
 			}
 		}
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -465,12 +465,14 @@ namespace stormphrax::search
 		{
 			m_ttable.probe(ttEntry, pos.key(), ply);
 
-			if (!PvNode
-				&& ttEntry.depth >= depth
-				&& (ttEntry.flag == TtFlag::Exact
+			if (!PvNode && ttEntry.depth >= depth)
+			{
+				if (ttEntry.flag == TtFlag::Exact
 					|| ttEntry.flag == TtFlag::UpperBound && ttEntry.score <= alpha
-					|| ttEntry.flag == TtFlag::LowerBound && ttEntry.score >= beta))
-				return ttEntry.score;
+					|| ttEntry.flag == TtFlag::LowerBound && ttEntry.score >= beta)
+					return ttEntry.score;
+				else ++depth;
+			}
 		}
 
 		const bool ttMoveNoisy = ttEntry.move && pos.isNoisy(ttEntry.move);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -471,7 +471,8 @@ namespace stormphrax::search
 					|| ttEntry.flag == TtFlag::UpperBound && ttEntry.score <= alpha
 					|| ttEntry.flag == TtFlag::LowerBound && ttEntry.score >= beta)
 					return ttEntry.score;
-				else depth += depth < 7;
+				else if (depth <= maxTtNonCutoffExtDepth())
+					++depth;
 			}
 		}
 

--- a/src/tunable.h
+++ b/src/tunable.h
@@ -48,7 +48,8 @@ namespace stormphrax::tunable
 	static_assert(Default >= Min); \
 	static_assert(Default <= Max); \
 	static_assert(Min < Max); \
-	static_assert(Min + Step <= Max);
+	static_assert(Min + Step <= Max); \
+	static_assert(Step >= 0.5);
 
 #if SP_EXTERNAL_TUNE
 	struct TunableParam
@@ -99,6 +100,8 @@ namespace stormphrax::tunable
 
 	SP_TUNABLE_PARAM(ttReplacementDepthOffset, 4, 0, 6, 0.5)
 	SP_TUNABLE_PARAM(ttReplacementPvOffset, 2, 0, 6, 0.5)
+
+	SP_TUNABLE_PARAM(maxTtNonCutoffExtDepth, 6, 0, 12, 0.5)
 
 	SP_TUNABLE_PARAM(minIirDepth, 3, 3, 6, 0.5)
 


### PR DESCRIPTION
```
Elo   | 4.14 +- 3.17 (95%)
SPRT  | 13.0+0.13s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 13832 W: 3313 L: 3148 D: 7371
Penta | [95, 1598, 3378, 1737, 108]
```
https://chess.swehosting.se/test/6685/