### PR TITLE
do no moveloop pruning at root

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -654,12 +654,11 @@ namespace stormphrax::search
 				? thread.history.noisyScore(move, captured)
 				: thread.history.quietScore(thread.conthist, ply, pos.threats(), moving, move);
 
-			if (bestScore > -ScoreWin)
+			if (!RootNode && bestScore > -ScoreWin)
 			{
 				if (!noisy)
 				{
-					if (!RootNode
-						&& legalMoves >= g_lmpTable[improving][std::min(depth, 15)])
+					if (legalMoves >= g_lmpTable[improving][std::min(depth, 15)])
 					{
 						generator.skipQuiets();
 						continue;


### PR DESCRIPTION
```
Elo   | 2.55 +- 2.99 (95%)
SPRT  | 13.0+0.13s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 15372 W: 3736 L: 3623 D: 8013
Penta | [91, 1830, 3757, 1891, 117]
```
https://chess.swehosting.se/test/6716/