### PR TITLE
successfully p-hack probcut into working

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -34,7 +34,8 @@ namespace stormphrax
 	enum class MovegenType
 	{
 		Normal = 0,
-		Qsearch
+		Qsearch,
+		Probcut
 	};
 
 	struct MovegenStage
@@ -50,7 +51,7 @@ namespace stormphrax
 	template <MovegenType Type>
 	class MoveGenerator
 	{
-		static constexpr bool NoisiesOnly = Type == MovegenType::Qsearch;
+		static constexpr bool NoisiesOnly = Type == MovegenType::Qsearch || Type == MovegenType::Probcut;
 
 	public:
 		MoveGenerator(const Position &pos, MovegenData &data, Move ttMove, const HistoryTables &history)
@@ -73,7 +74,8 @@ namespace stormphrax
 					switch (++m_stage)
 					{
 						case MovegenStage::TtMove:
-							if (m_ttMove && m_pos.isPseudolegal(m_ttMove))
+							if (m_ttMove && m_pos.isPseudolegal(m_ttMove)
+								)//&& (Type != MovegenType::Probcut || m_pos.isNoisy(m_ttMove)))
 								return m_ttMove;
 							break;
 
@@ -119,7 +121,7 @@ namespace stormphrax
 						const auto idx = findNext();
 						const auto move = m_data.moves[idx].move;
 
-						if constexpr (Type == MovegenType::Qsearch)
+						if constexpr (Type != MovegenType::Normal)
 							return move;
 						else
 						{
@@ -251,5 +253,11 @@ namespace stormphrax
 		MovegenData &data, const HistoryTables &history)
 	{
 		return MoveGenerator<MovegenType::Qsearch>(pos, data, NullMove, history);
+	}
+
+	[[nodiscard]] static inline auto probcutMoveGenerator(const Position &pos,
+		Move ttMove, MovegenData &data, const HistoryTables &history)
+	{
+		return MoveGenerator<MovegenType::Probcut>(pos, data, NullMove, history);
 	}
 }

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -74,8 +74,7 @@ namespace stormphrax
 					switch (++m_stage)
 					{
 						case MovegenStage::TtMove:
-							if (m_ttMove && m_pos.isPseudolegal(m_ttMove)
-								)//&& (Type != MovegenType::Probcut || m_pos.isNoisy(m_ttMove)))
+							if (m_ttMove && m_pos.isPseudolegal(m_ttMove))
 								return m_ttMove;
 							break;
 
@@ -258,6 +257,6 @@ namespace stormphrax
 	[[nodiscard]] static inline auto probcutMoveGenerator(const Position &pos,
 		Move ttMove, MovegenData &data, const HistoryTables &history)
 	{
-		return MoveGenerator<MovegenType::Probcut>(pos, data, NullMove, history);
+		return MoveGenerator<MovegenType::Probcut>(pos, data, ttMove, history);
 	}
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -564,7 +564,7 @@ namespace stormphrax::search
 				&& (!ttEntry.move || ttMoveNoisy)
 				&& !(ttHit && ttEntry.depth >= depth - 3 && ttEntry.score < probcutBeta))
 			{
-				const auto seeThreshold = probcutBeta > curr.staticEval ? 1 : 0;
+				const auto seeThreshold = probcutBeta - curr.staticEval;
 				const auto keyBefore = pos.key();
 
 				auto generator = probcutMoveGenerator(pos, ttEntry.move, moveStack.movegenData, thread.history);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -604,11 +604,9 @@ namespace stormphrax::search
 
 			if (depth >= 6
 				&& std::abs(beta) < ScoreWin
-				&& (!ttEntry.move || ttMoveNoisy)
-				&& !(ttHit && ttEntry.depth >= depth - 3 && ttEntry.score < probcutBeta))
+				&& (!ttEntry.move || ttMoveNoisy))
 			{
 				const auto seeThreshold = probcutBeta - curr.staticEval;
-				const auto keyBefore = pos.key();
 
 				auto generator = probcutMoveGenerator(pos, ttEntry.move, moveStack.movegenData, thread.history);
 
@@ -634,10 +632,7 @@ namespace stormphrax::search
 							moveStackIdx + 1, -probcutBeta, -probcutBeta + 1, !cutnode);
 
 					if (score >= probcutBeta)
-					{
-						m_ttable.put(keyBefore, score, curr.staticEval, move, depth - 3, ply, TtFlag::LowerBound);
 						return score;
-					}
 				}
 			}
 		}

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -578,6 +578,7 @@ namespace stormphrax::search
 
 					++thread.search.nodes;
 
+					m_ttable.prefetch(pos.roughKeyAfter(move));
 					const auto guard = pos.applyMove(move, &thread.nnueState);
 
 					auto score = -qsearch(thread, ply + 1, moveStackIdx + 1, -probcutBeta, -probcutBeta + 1);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -608,9 +608,10 @@ namespace stormphrax::search
 					return score > ScoreWin ? beta : score;
 			}
 
-			const auto probcutBeta = beta + 200 - 70 * improving;
+			const auto probcutBeta = beta + 300;
 
-			if (depth >= 6
+			if (!ttpv
+				&& depth >= 6
 				&& std::abs(beta) < ScoreWin
 				&& (!ttEntry.move || ttMoveNoisy)
 				&& !(ttHit && ttEntry.depth >= depth - 3 && ttEntry.score < probcutBeta))
@@ -643,7 +644,8 @@ namespace stormphrax::search
 
 					if (score >= probcutBeta)
 					{
-						m_ttable.put(keyBefore, score, curr.staticEval, move, depth - 3, ply, TtFlag::LowerBound);
+						m_ttable.put(keyBefore, score, curr.staticEval,
+							move, depth - 3, ply, TtFlag::LowerBound, false);
 						return score;
 					}
 				}

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -565,6 +565,7 @@ namespace stormphrax::search
 				&& !(ttHit && ttEntry.depth >= depth - 3 && ttEntry.score < probcutBeta))
 			{
 				const auto seeThreshold = probcutBeta > curr.staticEval ? 1 : 0;
+				const auto keyBefore = pos.key();
 
 				auto generator = probcutMoveGenerator(pos, ttEntry.move, moveStack.movegenData, thread.history);
 
@@ -589,7 +590,7 @@ namespace stormphrax::search
 
 					if (score >= probcutBeta)
 					{
-						m_ttable.put(pos.key(), score, move, depth - 3, ply, TtFlag::LowerBound);
+						m_ttable.put(keyBefore, score, move, depth - 3, ply, TtFlag::LowerBound);
 						return score;
 					}
 				}

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -559,7 +559,7 @@ namespace stormphrax::search
 			const bool ttMoveNoisy = ttEntry.move && pos.isNoisy(ttEntry.move);
 			const auto probcutBeta = beta + 200 - 70 * improving;
 
-			if (depth >= 5
+			if (depth >= 6
 				&& std::abs(beta) < ScoreWin
 				&& (!ttEntry.move || ttMoveNoisy)
 				&& !(ttHit && ttEntry.depth >= depth - 3 && ttEntry.score < probcutBeta))

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -580,6 +580,8 @@ namespace stormphrax::search
 					++thread.search.nodes;
 
 					m_ttable.prefetch(pos.roughKeyAfter(move));
+
+					curr.move = move;
 					const auto guard = pos.applyMove(move, &thread.nnueState);
 
 					auto score = -qsearch(thread, ply + 1, moveStackIdx + 1, -probcutBeta, -probcutBeta + 1);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -576,6 +576,8 @@ namespace stormphrax::search
 					if (!see::see(pos, move, seeThreshold))
 						continue;
 
+					++thread.search.nodes;
+
 					const auto guard = pos.applyMove(move, &thread.nnueState);
 
 					auto score = -qsearch(thread, ply + 1, moveStackIdx + 1, -probcutBeta, -probcutBeta + 1);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -557,7 +557,7 @@ namespace stormphrax::search
 			}
 
 			const bool ttMoveNoisy = ttEntry.move && pos.isNoisy(ttEntry.move);
-			const auto probcutBeta = beta + 200;
+			const auto probcutBeta = beta + 200 - 70 * improving;
 
 			if (depth >= 5
 				&& std::abs(beta) < ScoreWin

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -604,9 +604,11 @@ namespace stormphrax::search
 
 			if (depth >= 6
 				&& std::abs(beta) < ScoreWin
-				&& (!ttEntry.move || ttMoveNoisy))
+				&& (!ttEntry.move || ttMoveNoisy)
+				&& !(ttHit && ttEntry.depth >= depth - 3 && ttEntry.score < probcutBeta))
 			{
 				const auto seeThreshold = probcutBeta - curr.staticEval;
+				const auto keyBefore = pos.key();
 
 				auto generator = probcutMoveGenerator(pos, ttEntry.move, moveStack.movegenData, thread.history);
 
@@ -632,7 +634,10 @@ namespace stormphrax::search
 							moveStackIdx + 1, -probcutBeta, -probcutBeta + 1, !cutnode);
 
 					if (score >= probcutBeta)
+					{
+						m_ttable.put(keyBefore, score, curr.staticEval, move, depth - 3, ply, TtFlag::LowerBound);
 						return score;
+					}
 				}
 			}
 		}

--- a/src/tunable.h
+++ b/src/tunable.h
@@ -116,6 +116,11 @@ namespace stormphrax::tunable
 	SP_TUNABLE_PARAM(nmpBaseReduction, 4, 2, 5, 0.5)
 	SP_TUNABLE_PARAM(nmpDepthReductionDiv, 4, 1, 8, 1)
 
+	SP_TUNABLE_PARAM(minProbcutDepth, 6, 4, 8, 0.5)
+	SP_TUNABLE_PARAM(probcutMargin, 300, 150, 400, 13)
+	SP_TUNABLE_PARAM(probcutReduction, 3, 2, 5, 0.5)
+	SP_TUNABLE_PARAM(probcutSeeScale, 16, 6, 24, 1)
+
 	SP_TUNABLE_PARAM_CALLBACK(lmpBaseMoves, 3, 2, 5, 0.5, updateLmpTable)
 
 	SP_TUNABLE_PARAM(maxFpDepth, 8, 4, 12, 0.5)


### PR DESCRIPTION
```
Elo   | 0.58 +- 2.37 (95%)
SPRT  | 13.0+0.13s Threads=1 Hash=32MB
LLR   | -1.45 (-2.25, 2.89) [0.00, 5.00]
Games | N: 24434 W: 5830 L: 5789 D: 12815
Penta | [175, 2891, 6052, 2916, 183]
```
https://chess.swehosting.se/test/6719/
```
Elo   | 4.02 +- 3.03 (95%)
SPRT  | 65.0+0.65s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 12696 W: 2932 L: 2785 D: 6979
Penta | [41, 1372, 3361, 1547, 27]
```
https://chess.swehosting.se/test/6726/

scalimg