### PR TITLE
use lmr depth in depth condition for history pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -701,6 +701,8 @@ namespace stormphrax::search
 
 			if (!RootNode && bestScore > -ScoreWin)
 			{
+				const auto lmrDepth = std::max(depth - baseLmr, 0);
+
 				if (!noisy)
 				{
 					if (legalMoves >= g_lmpTable[improving][std::min(depth, 15)])
@@ -709,7 +711,7 @@ namespace stormphrax::search
 						continue;
 					}
 
-					if (depth <= maxHistoryPruningDepth()
+					if (lmrDepth <= maxHistoryPruningDepth()
 						&& history < historyPruningMargin() * depth + historyPruningOffset())
 					{
 						generator.skipQuiets();
@@ -725,8 +727,6 @@ namespace stormphrax::search
 						continue;
 					}
 				}
-
-				const auto lmrDepth = std::max(depth - baseLmr, 0);
 
 				const auto seeThreshold = noisy
 					? seePruningThresholdNoisy() * depth


### PR DESCRIPTION
```
Elo   | 3.25 +- 2.59 (95%)
SPRT  | 13.0+0.13s Threads=1 Hash=32MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 5.00]
Games | N: 20648 W: 4969 L: 4776 D: 10903
Penta | [127, 2439, 5046, 2538, 174]
```
https://chess.swehosting.se/test/6804/