### PR TITLE
bigger history bonus if static eval fails low

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -874,7 +874,9 @@ namespace stormphrax::search
 
 		if (bestMove)
 		{
-			const auto bonus = historyBonus(depth);
+			const auto historyDepth = depth + (curr.staticEval <= alpha);
+
+			const auto bonus = historyBonus(historyDepth);
 			const auto penalty = -bonus;
 
 			if (!pos.isNoisy(bestMove))


### PR DESCRIPTION
```
Elo   | 5.44 +- 3.83 (95%)
SPRT  | 13.0+0.13s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 9710 W: 2358 L: 2206 D: 5146
Penta | [78, 1105, 2340, 1251, 81]
```
