### PR TITLE
4-ply conthist, but weighted less

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -118,6 +118,7 @@ namespace stormphrax
 		{
 			updateConthist(continuations, ply, moving, move, bonus, 1);
 			updateConthist(continuations, ply, moving, move, bonus, 2);
+			updateConthist(continuations, ply, moving, move, bonus, 4);
 		}
 
 		inline auto updateQuietScore(std::span<ContinuationSubtable *> continuations,
@@ -141,6 +142,7 @@ namespace stormphrax
 
 			score += conthistScore(continuations, ply, moving, move, 1);
 			score += conthistScore(continuations, ply, moving, move, 2);
+			score += conthistScore(continuations, ply, moving, move, 4) / 2;
 
 			return score;
 		}


### PR DESCRIPTION
```
Elo   | 3.55 +- 2.81 (95%)
SPRT  | 13.0+0.13s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 17114 W: 4150 L: 3975 D: 8989
Penta | [109, 1957, 4261, 2110, 120]
```
https://chess.swehosting.se/test/6824/