### PR TITLE
don't do nmp where the tt indicates it would fail

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -591,6 +591,7 @@ namespace stormphrax::search
 			if (depth >= minNmpDepth()
 				&& curr.staticEval >= beta
 				&& !parent->move.isNull()
+				&& !(ttEntry.flag == TtFlag::UpperBound && ttEntry.score < beta)
 				&& !bbs.nonPk(us).empty())
 			{
 				m_ttable.prefetch(pos.key() ^ keys::color());


### PR DESCRIPTION
```
Elo   | 2.79 +- 2.26 (95%)
SPRT  | 13.0+0.13s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 27306 W: 6654 L: 6435 D: 14217
Penta | [205, 3176, 6688, 3363, 221]
```
https://chess.swehosting.se/test/6843/