### PR TITLE
reduce depth on aspiration window failhighs

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -352,7 +352,7 @@ namespace stormphrax::search
 				}
 				else
 				{
-					aspReduction = std::min(aspReduction + 1, 3);
+					aspReduction = std::min(aspReduction + 1, maxAspFailHighReduction());
 					beta = std::min(newScore + delta, ScoreInf);
 				}
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -326,9 +326,11 @@ namespace stormphrax::search
 
 			Score newScore{};
 
+			auto aspDepth = depth;
+
 			while (!hasStopped())
 			{
-				newScore = search<true, true>(thread, thread.rootPv, depth, 0, 0, alpha, beta, false);
+				newScore = search<true, true>(thread, thread.rootPv, aspDepth, 0, 0, alpha, beta, false);
 
 				if ((newScore > alpha && newScore < beta) || hasStopped())
 					break;
@@ -342,10 +344,16 @@ namespace stormphrax::search
 
 				if (newScore <= alpha)
 				{
+					aspDepth = depth;
+
 					beta = (alpha + beta) / 2;
 					alpha = std::max(newScore - delta, -ScoreInf);
 				}
-				else beta = std::min(newScore + delta, ScoreInf);
+				else
+				{
+					aspDepth = std::max(aspDepth - 1, depth - 3);
+					beta = std::min(newScore + delta, ScoreInf);
+				}
 
 				delta += delta * aspWideningFactor() / 16;
 			}

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -326,10 +326,11 @@ namespace stormphrax::search
 
 			Score newScore{};
 
-			auto aspDepth = depth;
+			i32 aspReduction = 0;
 
 			while (!hasStopped())
 			{
+				const auto aspDepth = std::max(depth - aspReduction, 1); // paranoia
 				newScore = search<true, true>(thread, thread.rootPv, aspDepth, 0, 0, alpha, beta, false);
 
 				if ((newScore > alpha && newScore < beta) || hasStopped())
@@ -344,14 +345,14 @@ namespace stormphrax::search
 
 				if (newScore <= alpha)
 				{
-					aspDepth = depth;
+					aspReduction = 0;
 
 					beta = (alpha + beta) / 2;
 					alpha = std::max(newScore - delta, -ScoreInf);
 				}
 				else
 				{
-					aspDepth = std::max(aspDepth - 1, depth - 3);
+					aspReduction = std::min(aspReduction + 1, 3);
 					beta = std::min(newScore + delta, ScoreInf);
 				}
 

--- a/src/tunable.h
+++ b/src/tunable.h
@@ -99,6 +99,8 @@ namespace stormphrax::tunable
 	SP_TUNABLE_PARAM(initialAspWindow, 30, 4, 50, 4)
 	SP_TUNABLE_PARAM(aspWideningFactor, 16, 1, 24, 1)
 
+	SP_TUNABLE_PARAM(maxAspFailHighReduction, 3, 1, 5, 1)
+
 	SP_TUNABLE_PARAM(ttReplacementDepthOffset, 4, 0, 6, 0.5)
 	SP_TUNABLE_PARAM(ttReplacementPvOffset, 2, 0, 6, 0.5)
 


### PR DESCRIPTION
```
Elo   | 3.15 +- 2.54 (95%)
SPRT  | 13.0+0.13s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 21036 W: 4986 L: 4795 D: 11255
Penta | [139, 2428, 5188, 2629, 134]
```
https://chess.swehosting.se/test/6900/