### PR TITLE
search tt moves in qsearch

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -204,7 +204,7 @@ namespace stormphrax
 			{
 				++m_stage;
 
-				if (m_ttMove && m_pos.isNoisy(m_ttMove) && m_pos.isPseudolegal(m_ttMove))
+				if (m_ttMove && m_pos.isPseudolegal(m_ttMove))
 					return m_ttMove;
 
 				[[fallthrough]];

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -63,6 +63,7 @@ namespace stormphrax
 		Quiet,
 		StartBadNoisy,
 		BadNoisy,
+		QsearchTtMove,
 		QsearchGenNoisy,
 		QsearchNoisy,
 		ProbcutTtMove,
@@ -199,6 +200,16 @@ namespace stormphrax
 				return NullMove;
 			}
 
+			case MovegenStage::QsearchTtMove:
+			{
+				++m_stage;
+
+				if (m_ttMove && m_pos.isNoisy(m_ttMove) && m_pos.isPseudolegal(m_ttMove))
+					return m_ttMove;
+
+				[[fallthrough]];
+			}
+
 			case MovegenStage::QsearchGenNoisy:
 			{
 				generateNoisy(m_data.moves, m_pos);
@@ -211,7 +222,7 @@ namespace stormphrax
 
 			case MovegenStage::QsearchNoisy:
 			{
-				if (const auto move = selectNext([](auto move) { return true; }))
+				if (const auto move = selectNext([this](auto move) { return move != m_ttMove; }))
 					return move;
 
 				m_stage = MovegenStage::End;
@@ -269,9 +280,9 @@ namespace stormphrax
 		}
 
 		[[nodiscard]] static inline auto qsearch(const Position &pos,
-			MovegenData &data, const HistoryTables &history)
+			MovegenData &data, Move ttMove, const HistoryTables &history)
 		{
-			return MoveGenerator(MovegenStage::QsearchGenNoisy, pos, data, NullMove, nullptr, history, {}, 0);
+			return MoveGenerator(MovegenStage::QsearchTtMove, pos, data, ttMove, nullptr, history, {}, 0);
 		}
 
 		[[nodiscard]] static inline auto probcut(const Position &pos,

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -991,7 +991,8 @@ namespace stormphrax::search
 
 		auto ttFlag = TtFlag::UpperBound;
 
-		auto generator = MoveGenerator::qsearch(pos, thread.moveStack[moveStackIdx].movegenData, thread.history);
+		auto generator = MoveGenerator::qsearch(pos,
+			thread.moveStack[moveStackIdx].movegenData, ttEntry.move, thread.history);
 
 		while (const auto move = generator.next())
 		{
@@ -1015,7 +1016,9 @@ namespace stormphrax::search
 			m_ttable.prefetch(pos.roughKeyAfter(move));
 			const auto guard = pos.applyMove(move, &thread.nnueState);
 
-			const auto score = -qsearch<PvNode>(thread, ply + 1, moveStackIdx + 1, -beta, -alpha);
+			const auto score = pos.isDrawn(false)
+				? drawScore(thread.search.nodes)
+				: -qsearch<PvNode>(thread, ply + 1, moveStackIdx + 1, -beta, -alpha);
 
 			if (score > bestScore)
 				bestScore = score;


### PR DESCRIPTION
```
Elo   | 2.53 +- 2.05 (95%)
SPRT  | 13.0+0.13s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 32288 W: 7659 L: 7424 D: 17205
Penta | [203, 3781, 7933, 4032, 195]
```
https://chess.swehosting.se/test/6917/