### PR TITLE
Nmp eval reduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -569,7 +569,8 @@ namespace stormphrax::search
 				m_ttable.prefetch(pos.key() ^ keys::color());
 
 				const auto R = nmpBaseReduction()
-					+ depth / nmpDepthReductionDiv();
+					+ depth / nmpDepthReductionDiv()
+					+ std::min((curr.staticEval - beta) / 200, 3);
 
 				thread.setNullmove(ply);
 				const auto guard = pos.applyNullMove();


### PR DESCRIPTION
```
Elo   | 4.10 +- 3.15 (95%)
SPRT  | 13.0+0.13s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 13884 W: 3392 L: 3228 D: 7264
Penta | [80, 1625, 3404, 1717, 116]
```
https://chess.swehosting.se/test/6925/