### PR TITLE
reduce more in nmp if improving

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -606,7 +606,8 @@ namespace stormphrax::search
 
 				const auto R = nmpBaseReduction()
 					+ depth / nmpDepthReductionDiv()
-					+ std::min((curr.staticEval - beta) / 200, 3);
+					+ std::min((curr.staticEval - beta) / 200, 3)
+					+ improving;
 
 				thread.setNullmove(ply);
 				const auto guard = pos.applyNullMove();


### PR DESCRIPTION
```
Elo   | 3.28 +- 2.61 (95%)
SPRT  | 13.0+0.13s Threads=1 Hash=32MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 5.00]
Games | N: 19592 W: 4664 L: 4479 D: 10449
Penta | [108, 2275, 4857, 2436, 120]
```
https://chess.swehosting.se/test/6932/