### PR TITLE
sf dodeeper/shallowersearch

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -798,7 +798,7 @@ namespace stormphrax::search
 				score = drawScore(thread.search.nodes);
 			else
 			{
-				const auto newDepth = depth + extension - 1;
+				auto newDepth = depth + extension - 1;
 
 				if (depth >= minLmrDepth()
 					&& legalMoves >= lmrMinMoves()
@@ -817,6 +817,11 @@ namespace stormphrax::search
 
 					if (score > alpha && reduced < newDepth)
 					{
+						const bool doDeeperSearch    = score > bestScore + 40 + 6 * newDepth;
+						const bool doShallowerSearch = score < bestScore + newDepth;
+
+						newDepth += doDeeperSearch - doShallowerSearch;
+
 						score = -search(thread, curr.pv, newDepth, ply + 1,
 							moveStackIdx + 1, -alpha - 1, -alpha, !cutnode);
 


### PR DESCRIPTION
```
Elo   | 3.10 +- 2.48 (95%)
SPRT  | 13.0+0.13s Threads=1 Hash=32MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 5.00]
Games | N: 21768 W: 5237 L: 5043 D: 11488
Penta | [121, 2523, 5437, 2647, 156]
```
https://chess.swehosting.se/test/6952/