### PR TITLE
faster movepicker

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -381,17 +381,18 @@ namespace stormphrax {
         }
 
         [[nodiscard]] inline u32 findNext() {
-            auto toU64 = [](i32 s) -> u64 {
+            const auto toU64 = [](i32 s) {
                 i64 widened = s;
                 widened -= std::numeric_limits<i32>::min();
                 return static_cast<u64>(widened) << 32;
             };
-            u64 best = toU64(m_data.moves[m_idx].score) | 256 - m_idx;
+
+            auto best = toU64(m_data.moves[m_idx].score) | (256 - m_idx);
             for (auto i = m_idx + 1; i < m_end; ++i) {
-                const auto cur = toU64(m_data.moves[i].score) | (256 - i);
+                const auto curr = toU64(m_data.moves[i].score) | (256 - i);
                 best = std::max(best, cur);
             }
-            const auto bestIdx = 256 - (best & 0xffffffff);
+            const auto bestIdx = 256 - (best & 0xFFFFFFFF);
             if (bestIdx != m_idx) {
                 std::swap(m_data.moves[m_idx], m_data.moves[bestIdx]);
             }

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -390,7 +390,7 @@ namespace stormphrax {
             auto best = toU64(m_data.moves[m_idx].score) | (256 - m_idx);
             for (auto i = m_idx + 1; i < m_end; ++i) {
                 const auto curr = toU64(m_data.moves[i].score) | (256 - i);
-                best = std::max(best, cur);
+                best = std::max(best, curr);
             }
             const auto bestIdx = 256 - (best & 0xFFFFFFFF);
             if (bestIdx != m_idx) {

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -20,12 +20,13 @@
 
 #include "types.h"
 
+#include <limits>
+
 #include "history.h"
 #include "movegen.h"
 #include "see.h"
 #include "stats.h"
 #include "tunable.h"
-#include <limits>
 
 namespace stormphrax {
     struct KillerTable {


### PR DESCRIPTION
```
Elo   | 1.37 +- 1.05 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 3.00]
Games | N: 151268 W: 39712 L: 39115 D: 72441
Penta | [2370, 17455, 35471, 17884, 2454]
```
https://chess.swehosting.se/test/11188/

`findBest` is now branchless and gets autovectorized pretty well.