### PR TITLE
northphrax: more corrhist

### DIFF
--- a/src/correction.cpp
+++ b/src/correction.cpp
@@ -80,6 +80,6 @@ namespace stormphrax {
         correction += contAdjustment(2, contCorrhist2Weight());
         correction += contAdjustment(4, contCorrhist4Weight());
 
-        return correction * 160 / 128;
+        return correction * 256 / 128;
     }
 } // namespace stormphrax

--- a/src/correction.cpp
+++ b/src/correction.cpp
@@ -80,6 +80,6 @@ namespace stormphrax {
         correction += contAdjustment(2, contCorrhist2Weight());
         correction += contAdjustment(4, contCorrhist4Weight());
 
-        return correction;
+        return correction * 160 / 128;
     }
 } // namespace stormphrax


### PR DESCRIPTION
```
Elo   | 22.66 +- 7.81 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 3.00]
Games | N: 4084 W: 1460 L: 1194 D: 1430
Penta | [128, 397, 785, 545, 187]
```
https://chess.swehosting.se/test/14294/